### PR TITLE
Added SSL layer for Celery <-> broker connection

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -303,3 +303,4 @@ terraform.rc
 
 # Ignore configs for docker-compose deploy
 configs/alts_config*.yaml
+deployment

--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,10 @@ terraform.rc
 
 # Ignore configs for docker-compose deploy
 configs/alts_config*.yaml
+
+# Ignore sensitive files from deployment
+deployment/hosts
+deployment/files/*.pem
+deployment/files/*.crt
+deployment/files/*/*.pem
+deployment/files/*/*.crt

--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -3,7 +3,7 @@ FROM centos:8
 ARG ARCH="amd64"
 ARG TF_VERSION="0.15.3"
 
-RUN mkdir -p /code ~/.terraform.d/plugin-cache ~/.ssh \
+RUN mkdir -p /code ~/.terraform.d/plugin-cache ~/.ssh /srv/celery_results \
     && echo "plugin_cache_dir = \"\$HOME/.terraform.d/plugin-cache\"" > ~/.terraformrc \
     && yum update -y \
     && yum install -y python3-virtualenv epel-release wget unzip yum-utils openssh-clients \

--- a/alts/scheduler/__init__.py
+++ b/alts/scheduler/__init__.py
@@ -8,17 +8,13 @@ import os
 
 from alts.shared.config_loader import get_config_dict_from_yaml
 from alts.shared.models import SchedulerConfig
+from alts.shared.utils.path_utils import get_abspath
 
 
 __all__ = ['CONFIG', 'CONFIG_FILE_PATH', 'DATABASE_NAME']
 
 
-CONFIG_FILE_PATH = os.path.abspath(
-    os.path.expandvars(
-        os.path.expanduser(
-            os.environ.get('SCHEDULER_CONFIG_PATH', '~/.config/alts/scheduler.yaml')
-        )
-    )
-)
+CONFIG_FILE_PATH = get_abspath(
+    os.environ.get('SCHEDULER_CONFIG_PATH', '~/.config/alts/scheduler.yaml'))
 CONFIG = get_config_dict_from_yaml(CONFIG_FILE_PATH, SchedulerConfig)
 DATABASE_NAME = 'scheduler.db'

--- a/alts/scheduler/app.py
+++ b/alts/scheduler/app.py
@@ -31,6 +31,7 @@ from alts.worker.mappings import RUNNER_MAPPING
 from alts.worker.tasks import run_tests
 from alts.scheduler import CONFIG
 from alts.scheduler.db import database, Session, Task
+from alts.shared.exceptions import ALTSBaseError
 from alts.shared.models import (
     TaskRequestResponse,
     TaskRequestPayload,
@@ -66,6 +67,12 @@ def get_celery_task_result(task_id: str, timeout: int = 1) -> dict:
         result['result'] = task_data.get(timeout=timeout)
     except TimeoutError:
         pass
+    except ALTSBaseError as e:
+        logging.warning(f'Task has failed with error: '
+                        f'{e.__class__.__name__}: {e}')
+    except Exception as e:
+        logging.error(f'Unknown exception while getting resutls from Celery: '
+                      f'{e.__class__.__name__}: {e}')
     result['state'] = task_data.state
     return result
 

--- a/alts/shared/utils/path_utils.py
+++ b/alts/shared/utils/path_utils.py
@@ -1,0 +1,12 @@
+import os
+
+
+__all__ = ['get_abspath']
+
+
+def get_abspath(file_path: str) -> str:
+    return os.path.abspath(
+        os.path.expandvars(
+            os.path.expanduser(file_path)
+        )
+    )

--- a/alts/worker/__init__.py
+++ b/alts/worker/__init__.py
@@ -9,18 +9,14 @@ from pathlib import Path
 
 from alts.shared.config_loader import get_config_dict_from_yaml
 from alts.shared.models import CeleryConfig
+from alts.shared.utils.path_utils import get_abspath
 
 
 __all__ = ['CONFIG', 'CONFIG_FILE_PATH', 'RESOURCES_DIR']
 
 
-CONFIG_FILE_PATH = os.path.abspath(
-    os.path.expandvars(
-        os.path.expanduser(
-            os.environ.get('CELERY_CONFIG_PATH', '~/.config/alts/celery.yaml')
-        )
-    )
-)
+CONFIG_FILE_PATH = get_abspath(
+    os.environ.get('CELERY_CONFIG_PATH', '~/.config/alts/celery.yaml'))
 CONFIG = get_config_dict_from_yaml(CONFIG_FILE_PATH, CeleryConfig)
 # Point to the project root directory
 BASE_DIR = os.path.abspath(Path(os.path.dirname(__file__)) / '../..')

--- a/alts/worker/app.py
+++ b/alts/worker/app.py
@@ -1,5 +1,6 @@
 from celery import Celery
 
+from alts.shared.utils.path_utils import get_abspath
 from alts.worker import CONFIG
 
 
@@ -8,7 +9,28 @@ __all__ = ['celery_app']
 
 celery_app = Celery('alts', include=['alts.worker.tasks'])
 celery_app.config_from_object(CONFIG)
-celery_app.conf.update(
-    result_accept_content=['json']
-)
+celery_app.conf.update(result_accept_content=['json'])
+
+if CONFIG.use_ssl:
+    if not CONFIG.ssl_config:
+        raise ValueError('Empty SSL configuration section')
+
+    # TODO: Figure out message signing with actual SSL certificates from CA
+    celery_app.conf.update(
+        # security_key=get_abspath(CONFIG.ssl_config.security_key),
+        # security_certificate=get_abspath(CONFIG.ssl_config.security_certificate),
+        # security_cert_store=CONFIG.ssl_config.security_cert_store,
+        # security_digest=CONFIG.ssl_config.security_digest,
+        # task_serializer='auth',
+        # event_serializer='auth',
+        # accept_content=['auth'],
+        broker_use_ssl={
+            'keyfile': get_abspath(CONFIG.ssl_config.security_key),
+            'certfile': get_abspath(CONFIG.ssl_config.security_certificate),
+            'ca_certs': get_abspath(CONFIG.ssl_config.broker_ca_certificates),
+            'cert_reqs': CONFIG.ssl_config.cert_required
+        },
+    )
+    # celery_app.setup_security()
+
 celery_app.autodiscover_tasks()

--- a/configs/example_config.yaml
+++ b/configs/example_config.yaml
@@ -1,6 +1,14 @@
 ---
+use_ssl: true
+ssl_config:
+  security_cert_store: '/etc/ssl/certs/*.crt'
+  security_key: ''
+  security_certificate: ''
+  broker_ca_certificates: ''
+  security_digest: 'sha256'
 rabbitqm_host: 'rabbitmq'
 rabbitmq_port: 5672
+rabbitmq_ssl_port: 5671
 rabbitmq_user: 'test-system'
 rabbitmq_password:
 rabbitmq_vhost: 'test_system'

--- a/deployment/ansible.cfg
+++ b/deployment/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+host_key_checking = False

--- a/deployment/celery_playbook.yml
+++ b/deployment/celery_playbook.yml
@@ -1,0 +1,9 @@
+---
+
+- name: Install Celery
+  hosts: celery
+  roles:
+    - base
+    - docker
+    - celery
+    - terraform

--- a/deployment/group_vars/all
+++ b/deployment/group_vars/all
@@ -1,0 +1,33 @@
+---
+
+rabbitmq_ssl: true
+rabbitmq_copy_ssl_files: true
+rabbitmq_admin_user: admin
+rabbitmq_admin_password: some-secret-password
+rabbitmq_ssl_folder: "/etc/rabbitmq/ssl/"
+rabbitmq_cacert: "files/rabbitmq/ca_certificate.pem"
+rabbitmq_server_key: "files/rabbitmq/server_key.pem"
+rabbitmq_server_cert: "files/rabbitmq/server_certificate.pem"
+rabbitmq_conf_ssl_options_cacertfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_cacert | basename }}"
+rabbitmq_conf_ssl_options_keyfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_server_key | basename }}"
+rabbitmq_conf_ssl_options_certfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_server_cert | basename }}"
+rabbitmq_ssl_verify: "verify_peer"
+rabbitmq_ssl_fail_if_no_peer_cert: true
+rabbitmq_test_system_password: some-another-secret-password
+rabbitmq_test_system_vhost: /test-system
+
+test_system_user: test-system
+test_system_config_dir: ~/.config/alts
+
+celery_ssl: "{{ rabbitmq_ssl }}"
+celery_ssl_src_certificate: "files/celery/client_certificate.pem"
+celery_ssl_src_key: "files/celery/client_key.pem"
+celery_src_cacert: "{{ rabbitmq_cacert }}"
+celery_ssl_dir: "{{ test_system_config_dir }}/ssl"
+celery_ssl_certificate: "{{ celery_ssl_dir }}/{{ celery_ssl_src_certificate | basename }}"
+celery_ssl_key: "{{ celery_ssl_dir }}/{{ celery_ssl_src_key | basename }}"
+celery_cacert: "{{ celery_ssl_dir }}/{{ celery_src_cacert | basename }}"
+celery_concurrency: 10
+celery_loglevel: INFO
+celery_queues:
+  - "docker-x86_64-0"

--- a/deployment/group_vars/celery
+++ b/deployment/group_vars/celery
@@ -1,0 +1,30 @@
+---
+
+test_system_user: test-system
+test_system_vhost: test_system
+test_system_password: some-another-secret-password
+test_system_config_dir: ~/.config/alts
+
+rabbitmq_host: localhost
+rabbitmq_port: 5672
+rabbitmq_ssl_port: 5671
+
+celery_ssl: true
+celery_ssl_src_certificate: "files/celery/client_certificate.pem"
+celery_ssl_src_key: "files/celery/client_key.pem"
+celery_src_cacert: "files/ca_certificate.pem"
+celery_ssl_dir: "{{ test_system_config_dir }}/ssl"
+celery_ssl_certificate: "{{ celery_ssl_dir }}/{{ celery_ssl_src_certificate | basename }}"
+celery_ssl_key: "{{ celery_ssl_dir }}/{{ celery_ssl_src_key | basename }}"
+celery_cacert: "{{ celery_ssl_dir }}/{{ celery_src_cacert | basename }}"
+
+result_backend_name: local
+celery_result_folder: /srv/celery_results
+
+celery_pid_file_dir: /var/run/celery
+celery_pid_file: "{{ celery_pid_file_dir }}/worker.pid"
+celery_concurrency: 10
+celery_loglevel: INFO
+celery_queues:
+  - "docker-x86_64-0"
+opennebula_templates:

--- a/deployment/group_vars/rabbitmq
+++ b/deployment/group_vars/rabbitmq
@@ -1,0 +1,19 @@
+---
+
+rabbitmq_ssl: true
+rabbitmq_port: 5672
+rabbitmq_ssl_port: 5671
+rabbitmq_copy_ssl_files: true
+rabbitmq_admin_user: admin
+rabbitmq_admin_password: some-secret-password
+rabbitmq_ssl_folder: "/etc/rabbitmq/ssl"
+rabbitmq_cacert: "files/ca_certificate.pem"
+rabbitmq_server_key: "files/rabbitmq/server_key.pem"
+rabbitmq_server_cert: "files/rabbitmq/server_certificate.pem"
+rabbitmq_conf_ssl_options_cacertfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_cacert | basename }}"
+rabbitmq_conf_ssl_options_keyfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_server_key | basename }}"
+rabbitmq_conf_ssl_options_certfile: "{{ rabbitmq_ssl_folder }}/{{ rabbitmq_server_cert | basename }}"
+rabbitmq_ssl_verify: "verify_peer"
+rabbitmq_ssl_fail_if_no_peer_cert: true
+rabbitmq_test_system_password: some-another-secret-password
+rabbitmq_test_system_vhost: test_system

--- a/deployment/group_vars/scheduler
+++ b/deployment/group_vars/scheduler
@@ -1,0 +1,32 @@
+---
+
+test_system_user: test-system
+test_system_vhost: test_system
+test_system_password: some-another-secret-password
+test_system_config_dir: ~/.config/alts
+
+rabbitmq_host: localhost
+rabbitmq_port: 5672
+rabbitmq_ssl_port: 5671
+
+celery_ssl: true
+celery_ssl_src_certificate: "files/celery/client_certificate.pem"
+celery_ssl_src_key: "files/celery/client_key.pem"
+celery_src_cacert: "files/ca_certificate.pem"
+celery_ssl_dir: "{{ test_system_config_dir }}/ssl"
+celery_ssl_certificate: "{{ celery_ssl_dir }}/{{ celery_ssl_src_certificate | basename }}"
+celery_ssl_key: "{{ celery_ssl_dir }}/{{ celery_ssl_src_key | basename }}"
+celery_cacert: "{{ celery_ssl_dir }}/{{ celery_src_cacert | basename }}"
+
+result_backend_name: local
+celery_result_folder: /srv/celery_results
+
+celery_pid_file_dir: /var/run/celery
+celery_pid_file: "{{ celery_pid_file_dir }}/worker.pid"
+celery_concurrency: 10
+celery_loglevel: INFO
+celery_queues:
+  - "docker-x86_64-0"
+
+scheduler_working_directory: /srv/alts/scheduler
+jwt_secret: very-secret-on5

--- a/deployment/rabbitmq_playbook.yml
+++ b/deployment/rabbitmq_playbook.yml
@@ -1,0 +1,6 @@
+---
+- name: Install RabbitMQ and setup TLS
+  hosts: rabbitmq
+  roles:
+    - base
+    - rabbitmq-server

--- a/deployment/roles/base/tasks/main.yml
+++ b/deployment/roles/base/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+
+- name: Install yum-utils
+  yum:
+    name: yum-utils
+    state: present
+
+- name: Update all packages
+  yum:
+    name: "*"
+    state: latest
+
+- name: Install EPEL repository
+  yum:
+    name: epel-release
+    state: present

--- a/deployment/roles/celery/defaults/main.yml
+++ b/deployment/roles/celery/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+celery_venv_dir: ~/.venv-celery
+opennebula_endpoint:
+opennebula_user:
+opennebula_password:
+opennebula_vm_group:
+scheduler_http_port: 8000

--- a/deployment/roles/celery/handlers/main.yml
+++ b/deployment/roles/celery/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Reload Celery service file
+  systemd:
+    service: alts-celery
+    state: reloaded

--- a/deployment/roles/celery/tasks/main.yml
+++ b/deployment/roles/celery/tasks/main.yml
@@ -1,0 +1,95 @@
+---
+
+- name: Install python-pip and python-venv
+  yum:
+    name: ["python3-pip", "python3-virtualenv"]
+    state: present
+
+- name: Install git
+  yum:
+    name: git
+    state: present
+
+- name: Add Celery user
+  user:
+    name: "{{ test_system_user }}"
+    groups: docker
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: .ssh/id_rsa
+    state: present
+
+- name: Configure Celery user
+  become: yes
+  become_user: "{{ test_system_user }}"
+  block:
+    - name: Clone ALTS repository
+      git:
+        repo: https://github.com/AlmaLinux/alts
+        dest: ~/alts
+        depth: 1
+
+    - name: Install Celery dependencies
+      pip:
+        virtualenv: "{{ celery_venv_dir }}"
+        requirements: ~/alts/requirements/celery.txt
+
+    - name: Create config and SSL folder
+      file:
+        path: "{{ item }}"
+        mode: 0755
+        state: directory
+      with_items:
+        - "{{ test_system_config_dir }}"
+        - "{{ celery_ssl_dir }}"
+
+    - name: Copy the ssl certificates
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "{{ test_system_user }}"
+        group: "{{ test_system_user }}"
+        mode: 0600
+        backup: "yes"
+      with_items:
+        - { src: "{{ celery_src_cacert }}", dest: "{{ celery_cacert }}" }
+        - { src: "{{ celery_ssl_src_key }}", dest: "{{ celery_ssl_key }}" }
+        - { src: "{{ celery_ssl_src_certificate }}", dest: "{{ celery_ssl_certificate }}" }
+      when: celery_ssl
+
+    - name: Create Celery config
+      template:
+        src: service_config.yaml.j2
+        dest: "{{ test_system_config_dir }}/celery.yaml"
+
+- name: Create Celery Systemd service file
+  template:
+    src: alts-celery.service.j2
+    dest: /etc/systemd/system/alts-celery.service
+    mode: 0644
+
+- name: Create PID files directory for Celery service
+  file:
+    path: "{{ celery_pid_file_dir }}"
+    mode: 0755
+    owner: "{{ test_system_user }}"
+    group: "{{ test_system_user }}"
+    state: directory
+
+- name: Create folder for Celery local results
+  file:
+    path: "{{ celery_result_folder }}"
+    mode: 0755
+    owner: "{{ test_system_user }}"
+    group: "{{ test_system_user }}"
+    state: directory
+  when: result_backend_name is defined and result_backend_name == 'local'
+
+- name: Reload Celery service file
+  command: systemctl daemon-reload
+
+- name: Enable and start Celery service
+  service:
+    name: alts-celery
+    enabled: yes
+    state: started

--- a/deployment/roles/docker/tasks/main.yml
+++ b/deployment/roles/docker/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+
+- name: Add Docker repository
+  yum_repository:
+    name: docker-ce-stable
+    file: docker-ce
+    description: Docker CE stable repository
+    baseurl: https://download.docker.com/linux/centos/$releasever/$basearch/stable
+    gpgcheck: yes
+    state: present
+
+- name: Add Docker repository GPG key
+  rpm_key:
+    key: https://download.docker.com/linux/centos/gpg
+    state: present
+
+- name: Install Docker CE
+  yum:
+    name: ["docker-ce", "docker-ce-cli", "containerd.io"]
+    state: present
+
+- name: Start Docker service
+  service:
+    name: docker
+    enabled: yes
+    state: started

--- a/deployment/roles/rabbitmq-server/defaults/main.yml
+++ b/deployment/roles/rabbitmq-server/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+
+rabbitmq_port: 5672
+rabbitmq_ssl_port: 5671

--- a/deployment/roles/rabbitmq-server/handlers/main.yml
+++ b/deployment/roles/rabbitmq-server/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: restart rabbitmq
+  service:
+    name: rabbitmq-server
+    state: restarted

--- a/deployment/roles/rabbitmq-server/tasks/main.yml
+++ b/deployment/roles/rabbitmq-server/tasks/main.yml
@@ -1,0 +1,162 @@
+---
+
+- name: Install RabbitMQ repository
+  block:
+    - name: Download repository setup script
+      get_url:
+        url: https://packagecloud.io/install/repositories/rabbitmq/rabbitmq-server/script.rpm.sh
+        dest: /tmp/rabbitm-repo-setup.sh
+        mode: 0755
+
+    - name: Execute repository setup script
+      command: /tmp/rabbitm-repo-setup.sh
+      environment:
+        os: el
+        dist: 8
+
+    - name: Delete setup script
+      file:
+        path: /tmp/rabbitm-repo-setup.sh
+        state: absent
+
+- name: Add Erlang repository
+  yum_repository:
+    name: erlang-latest
+    file: erlang
+    description: Erlang repository
+    baseurl: https://packagecloud.io/rabbitmq/erlang/el/$releasever/$basearch
+    gpgcheck: yes
+    state: present
+
+- name: Add Erlang repository GPG key
+  rpm_key:
+    key: https://packagecloud.io/rabbitmq/erlang/gpgkey
+    state: present
+
+- name: Install RabbitMQ server
+  yum:
+    name: rabbitmq-server
+    state: present
+    enablerepo: epel,powertools
+
+- name: Enable management plugin
+  rabbitmq_plugin:
+    names: rabbitmq_management
+    state: enabled
+  notify:
+    - restart rabbitmq
+
+- name: Flush handlers
+  meta: flush_handlers
+
+- name: Add RabbitMQ user
+  rabbitmq_user:
+    user: "{{ rabbitmq_admin_user }}"
+    password: "{{ rabbitmq_admin_password }}"
+    vhost: /
+    tags: administrator
+    configure_priv: .*
+    read_priv: .*
+    write_priv: .*
+    state: present
+
+- name: Add test system vhost
+  rabbitmq_vhost:
+    name: "{{ rabbitmq_test_system_vhost }}"
+    state: present
+
+- name: Add RabbitMQ test system user
+  rabbitmq_user:
+    user: "{{ test_system_user }}"
+    password: "{{ rabbitmq_test_system_password }}"
+    vhost: "{{ rabbitmq_test_system_vhost }}"
+    tags: test-system
+    configure_priv: .*
+    read_priv: .*
+    write_priv: .*
+    state: present
+
+- name: Add AMQP port to firewall
+  firewalld:
+    zone: public
+    port: "{{ item }}"
+    state: enabled
+    permanent: yes
+    immediate: yes
+  with_items:
+    - "{{ rabbitmq_port }}/tcp"
+    - "{{ rabbitmq_port }}/udp"
+
+- name: Configure SSL
+  block:
+    - name: Create SSL folder for rabbitmq
+      file:
+        path: "/etc/rabbitmq/ssl/"
+        owner: "rabbitmq"
+        group: "rabbitmq"
+        mode: 0750
+        state: "directory"
+      when: rabbitmq_ssl and rabbitmq_copy_ssl_files
+
+    - name: Copy the ssl certificates
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "rabbitmq"
+        group: "rabbitmq"
+        mode: 0640
+        backup: "yes"
+      with_items:
+        - { src: "{{ rabbitmq_cacert }}", dest: "{{ rabbitmq_conf_ssl_options_cacertfile }}" }
+        - { src: "{{ rabbitmq_server_key }}", dest: "{{ rabbitmq_conf_ssl_options_keyfile }}" }
+        - { src: "{{ rabbitmq_server_cert }}", dest: "{{ rabbitmq_conf_ssl_options_certfile }}" }
+
+    - name: Update configuration file as per parameters
+      ini_file:
+        path: /etc/rabbitmq/rabbitmq.conf
+        section:
+        option: "{{ item.name }}"
+        value: "{{ item.value }}"
+        state: present
+      with_items:
+        - { name: listeners.ssl.default, value: "{{ rabbitmq_ssl_port }}" }
+        - { name: ssl_options.verify, value: "{{ rabbitmq_ssl_verify }}" }
+        - { name: ssl_options.fail_if_no_peer_cert, value: "{{ rabbitmq_ssl_fail_if_no_peer_cert | to_json }}" }
+        - { name: ssl_options.cacertfile, value: "{{ rabbitmq_conf_ssl_options_cacertfile }}" }
+        - { name: ssl_options.certfile, value: "{{ rabbitmq_conf_ssl_options_certfile }}" }
+        - { name:  ssl_options.keyfile, value: "{{ rabbitmq_conf_ssl_options_keyfile }}" }
+
+      notify:
+        - restart rabbitmq
+
+    - name: Add AMQPS port to firewall
+      firewalld:
+        zone: public
+        port: "{{ item }}"
+        state: enabled
+        permanent: yes
+        immediate: yes
+      with_items:
+        - "{{ rabbitmq_ssl_port }}/tcp"
+        - "{{ rabbitmq_ssl_port }}/udp"
+
+    - name: Flush handlers
+      meta: flush_handlers
+
+  when: rabbitmq_ssl and rabbitmq_copy_ssl_files
+
+- name: Enable AMQP/AMQPS services on firewall
+  firewalld:
+    zone: public
+    service: "{{ item }}"
+    state: enabled
+    permanent: yes
+  with_items:
+    - amqp
+    - amqps
+
+- name: Enable and start RabbitMQ service
+  service:
+    name: rabbitmq-server
+    enabled: yes
+    state: started

--- a/deployment/roles/scheduler/defaults/main.yml
+++ b/deployment/roles/scheduler/defaults/main.yml
@@ -1,0 +1,9 @@
+---
+
+scheduler_venv_dir: ~/.venv-scheduler
+
+opennebula_endpoint:
+opennebula_user:
+opennebula_password:
+opennebula_vm_group:
+scheduler_http_port: 8000

--- a/deployment/roles/scheduler/tasks/main.yml
+++ b/deployment/roles/scheduler/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+
+- name: Install python-pip and python-venv
+  yum:
+    name: ["python3-pip", "python3-virtualenv"]
+    state: present
+
+- name: Install git
+  yum:
+    name: git
+    state: present
+
+- name: Add scheduler user
+  user:
+    name: "{{ test_system_user }}"
+    generate_ssh_key: yes
+    ssh_key_bits: 4096
+    ssh_key_file: .ssh/id_rsa
+    state: present
+
+- name: Configure scheduler user
+  become: yes
+  become_user: "{{ test_system_user }}"
+  block:
+    - name: Clone ALTS repository
+      git:
+        repo: https://github.com/AlmaLinux/alts
+        dest: ~/alts
+        depth: 1
+
+    - name: Install scheduler dependencies
+      pip:
+        virtualenv: "{{ scheduler_venv_dir }}"
+        requirements: ~/alts/requirements/scheduler.txt
+
+    - name: Create config and SSL folder
+      file:
+        path: "{{ item }}"
+        mode: 0755
+        state: directory
+      with_items:
+        - "{{ test_system_config_dir }}"
+        - "{{ celery_ssl_dir }}"
+
+    - name: Copy the ssl certificates
+      copy:
+        src: "{{ item.src }}"
+        dest: "{{ item.dest }}"
+        owner: "{{ test_system_user }}"
+        group: "{{ test_system_user }}"
+        mode: 0600
+        backup: "yes"
+      with_items:
+        - { src: "{{ celery_src_cacert }}", dest: "{{ celery_cacert }}" }
+        - { src: "{{ celery_ssl_src_key }}", dest: "{{ celery_ssl_key }}" }
+        - { src: "{{ celery_ssl_src_certificate }}", dest: "{{ celery_ssl_certificate }}" }
+      when: celery_ssl
+
+    - name: Create scheduler config
+      template:
+        src: service_config.yaml.j2
+        dest: "{{ test_system_config_dir }}/scheduler.yaml"
+
+- name: Create scheduler working directory
+  file:
+    path: "{{ scheduler_working_directory }}"
+    mode: 0755
+    owner: "{{ test_system_user }}"
+    group: "{{ test_system_user }}"
+    state: directory
+  when: scheduler_working_directory is defined and scheduler_working_directory
+
+
+- name: Enable HTTP/HTTPS services on firewall
+  firewalld:
+    zone: public
+    service: "{{ item }}"
+    state: enabled
+    permanent: yes
+  with_items:
+    - http
+    - https
+
+- name: Add scheduler port to firewall
+  firewalld:
+    zone: public
+    port: "{{ scheduler_http_port }}/tcp"
+    state: enabled
+    permanent: yes
+    immediate: yes
+
+- name: Create scheduler Systemd service file
+  template:
+    src: alts-scheduler.service.j2
+    dest: /etc/systemd/system/alts-scheduler.service
+    mode: 0644
+
+- name: Reload scheduler service file
+  command: systemctl daemon-reload
+
+- name: Enable and start scheduler service
+  service:
+    name: alts-scheduler
+    enabled: yes
+    state: started

--- a/deployment/roles/terraform/defaults/main.yml
+++ b/deployment/roles/terraform/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+terraform_plugin_cache_dir: ~/.terraform.d/plugins-cache
+terraform_version: 0.15.4
+terraform_arch: amd64

--- a/deployment/roles/terraform/tasks/main.yml
+++ b/deployment/roles/terraform/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+
+- name: Install unzip package
+  yum:
+    name: unzip
+    state: present
+
+- name: Download Terraform
+  get_url:
+    url: "https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_{{ terraform_arch }}.zip"
+    dest: /tmp/terraform.zip
+
+- name: Unpack Terraform
+  unarchive:
+    src: /tmp/terraform.zip
+    dest: /usr/local/bin
+    remote_src: yes
+
+- name: Configure Terraform for test system user
+  become: yes
+  become_user: "{{ test_system_user }}"
+  block:
+    - name: Add Terraform plugin cache directory
+      file:
+        path: "{{ terraform_plugin_cache_dir }}"
+        owner: "{{ test_system_user }}"
+        group: "{{ test_system_user }}"
+        mode: 0755
+        state: directory
+
+    - name: Create Terraform configuration file
+      template:
+        src: terraformrc.j2
+        dest: ~/.terraformrc
+        owner: "{{ test_system_user }}"
+        group: "{{ test_system_user }}"
+        mode: 0644

--- a/deployment/scheduler_playbook.yml
+++ b/deployment/scheduler_playbook.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Configure scheduler
+  hosts: scheduler
+  roles:
+    - base
+    - scheduler

--- a/deployment/templates/alts-celery.service.j2
+++ b/deployment/templates/alts-celery.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Celery worker for AL test system
+After=network.target
+
+[Service]
+User={{ test_system_user }}
+Group={{ test_system_user }}
+Environment=CELERY_CONFIG_PATH={{ test_system_config_dir }}/celery.yaml
+ExecStart=/bin/sh -c 'source {{ celery_venv_dir }}/bin/activate && cd ~/alts && celery -A alts.worker.app worker \
+    --pool=threads --concurrency={{ celery_concurrency }} --loglevel={{ celery_loglevel }} \
+    -Q {{ celery_queues|join(",") }} --pidfile={{ celery_pid_file }}'
+ExecStop=/bin/sh -c 'source ~/{{ celery_venv_dir }}/bin/activate && celery -A alts.worker.app stop --pidfile={{ celery_pid_file }}'
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/templates/alts-scheduler.service.j2
+++ b/deployment/templates/alts-scheduler.service.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Scheduler service for AL test system
+After=network.target
+
+[Service]
+User={{ test_system_user }}
+Group={{ test_system_user }}
+Environment=CELERY_CONFIG_PATH={{ test_system_config_dir }}/scheduler.yaml
+Environment=SCHEDULER_FILE_PATH={{ test_system_config_dir }}/scheduler.yaml
+ExecStart=/bin/sh -c 'source {{ scheduler_venv_dir }}/bin/activate && cd ~/alts && uvicorn --host 0.0.0.0 \
+    --port {{ scheduler_http_port }} alts.scheduler.app:app'
+
+[Install]
+WantedBy=multi-user.target

--- a/deployment/templates/service_config.yaml.j2
+++ b/deployment/templates/service_config.yaml.j2
@@ -1,0 +1,54 @@
+---
+{% if celery_ssl %}
+use_ssl: true
+ssl_config:
+  security_key: {{ celery_ssl_key }}
+  security_certificate: {{ celery_ssl_certificate }}
+  broker_ca_certificates: {{ celery_cacert }}
+{% endif %}
+
+rabbitmq_host: {{ rabbitmq_host }}
+rabbitmq_port: {{ rabbitmq_port }}
+{% if celery_ssl %}
+rabbitmq_ssl_port: {{ rabbitmq_ssl_port }}
+{% endif %}
+rabbitmq_user: {{ test_system_user }}
+rabbitmq_password: {{ test_system_password }}
+rabbitmq_vhost: {{ test_system_vhost }}
+
+{% if result_backend_name == 'local' and celery_result_folder %}
+result_backend: file://{{ celery_result_folder }}
+{% else %}
+result_backend: result_backend_name
+{% endif %}
+
+{% if result_backend_name == 's3' %}
+s3_access_key_id: {{ s3_key_id }}
+s3_secret_access_key: {{ s3_access_key }}
+s3_bucket: {{ s3_bucket }}
+s3_base_path: 'celery_result_backend/'
+s3_region: {{ s3_region }}
+s3_endpoint_url:
+{% endif %}
+
+task_default_queue: 'default'
+task_acks_late: true
+task_track_started: true
+artifacts_root_directory: 'test_system_artifacts'
+worker_prefetch_multiplier: 1
+
+{% if opennebula_endpoint and opennebula_user and opennebula_password and opennebula_vm_group and opennebula_templates %}
+opennebula_rpc_endpoint: {{ opennebula_endpoint }}
+opennebula_username: {{ opennebula_user }}
+opennebula_password: {{ opennebula_password }}
+opennebula_vm_group: {{ opennebula_vm_group }}
+opennebula_templates:
+    {{ opennebula_templates }}
+{% endif %}
+
+{% if jwt_secret | default('') %}
+jwt_secret: {{ jwt_secret }}
+{% endif %}
+{% if scheduler_working_directory | default('') %}
+working_directory: {{ scheduler_working_directory }}
+{% endif %}

--- a/deployment/templates/terraformrc.j2
+++ b/deployment/templates/terraformrc.j2
@@ -1,0 +1,1 @@
+plugin_cache_dir = "{{ terraform_plugin_cache_dir }}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,26 @@ services:
     container_name: "rabbitmq-ts"
     ports:
       - 5672:5672
+      - 5671:5671
       - 15672:15672
     environment:
       RABBITMQ_ERLANG_COOKIE: PyekdgANDctdPgRzU8AVaRBK
       RABBITMQ_DEFAULT_USER: test-system
       RABBITMQ_DEFAULT_PASS: # Your secret password here
       RABBITMQ_DEFAULT_VHOST: test_system
+      RABBITMQ_SSL_CACERTFILE: /opt/ssl/ca_certificate.pem
+      RABBITMQ_SSL_CERTFILE: /opt/ssl/server/server_certificate.pem
+      RABBITMQ_SSL_KEYFILE: /opt/ssl/server/server_key.pem
+      RABBITMQ_SSL_VERIFY: "verify_peer"
+      RABBITMQ_SSL_FAIL_IF_NO_PEER_CERT: "true"
+      RABBITMQ_MANAGEMENT_SSL_CACERTFILE: /opt/ssl/ca_certificate.pem
+      RABBITMQ_MANAGEMENT_SSL_CERTFILE: /opt/ssl/server/server_certificate.pem
+      RABBITMQ_MANAGEMENT_SSL_KEYFILE: /opt/ssl/server/server_key.pem
+      RABBITMQ_MANAGEMENT_SSL_VERIFY: "verify_peer"
+      RABBITMQ_MANAGEMENT_SSL_FAIL_IF_NO_PEER_CERT: "true"
+    volumes:
+      - $your_ssl_folder:/opt/ssl
+
     restart: always
 
   celery:
@@ -29,6 +43,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./configs/alts_config.yaml:/celery_config.yaml
+      - $your_ssl_folder:/opt/ssl
     depends_on:
       - rabbitmq
 
@@ -47,5 +62,6 @@ services:
       - 8000:8000
     volumes:
       - ./configs/alts_config.yaml:/scheduler_config.yaml
+      - $your_ssl_folder:/opt/ssl
     depends_on:
       - rabbitmq

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,3 +7,4 @@ pydantic==1.8.1
 ruamel.yaml==0.17.4
 jmespath==0.10.0
 requests==2.25.1
+cryptography==3.4.7


### PR DESCRIPTION
This commit brings the following changes:
- Communication between Celery workers and RabbitMQ broker uses SSL for
encryption now;
- Added deployment playbooks for RabbitMQ server, Celery worker node and
Scheduler node;
- Fixed issues with configuring Celery to use local results backend.