### PR TITLE
Fix monitoring launched tasks

### DIFF
--- a/alts/scheduler/app.py
+++ b/alts/scheduler/app.py
@@ -98,8 +98,9 @@ async def startup():
         tasks_for_update = []
         for task in session.query(Task).filter(Task.status == 'STARTED'):
             task_result = celery_app.AsyncResult(task.task_id)
-            task.status = task_result.state
-            tasks_for_update.append(task)
+            if task.status != task_result.state:
+                task.status = task_result.state
+                tasks_for_update.append(task)
         if tasks_for_update:
             session.add_all(tasks_for_update)
             session.commit()

--- a/alts/scheduler/app.py
+++ b/alts/scheduler/app.py
@@ -6,14 +6,12 @@
 
 import logging
 import random
-import time
+import signal
 import traceback
 import uuid
-from datetime import datetime, timedelta
+from threading import Event
 
-import requests
 from celery.exceptions import TimeoutError
-from celery.states import READY_STATES
 from fastapi import (
     BackgroundTasks,
     Depends,
@@ -26,21 +24,25 @@ from fastapi.security import HTTPBearer
 from jose import JWTError, jwt
 from pydantic import ValidationError
 
-from alts.worker.app import celery_app
-from alts.worker.mappings import RUNNER_MAPPING
-from alts.worker.tasks import run_tests
 from alts.scheduler import CONFIG
 from alts.scheduler.db import database, Session, Task
+from alts.scheduler.monitoring import TasksMonitor
+from alts.shared.constants import API_VERSION
 from alts.shared.exceptions import ALTSBaseError
 from alts.shared.models import (
     TaskRequestResponse,
     TaskRequestPayload,
     TaskResultResponse,
 )
+from alts.worker.app import celery_app
+from alts.worker.mappings import RUNNER_MAPPING
+from alts.worker.tasks import run_tests
 
-# YYYYMMDD format for API version
-API_VERSION = '20210512'
+
 app = FastAPI()
+monitor = None
+terminate_event = Event()
+graceful_terminate_event = Event()
 http_bearer_scheme = HTTPBearer()
 
 
@@ -77,49 +79,6 @@ def get_celery_task_result(task_id: str, timeout: int = 1) -> dict:
     return result
 
 
-# TODO: Make background functions react to application stop
-def check_celery_task_result(task_id: str, callback_url: str = None):
-    """
-    Gets Test System task result info from Celery.
-
-    Parameters
-    ----------
-    task_id : str
-        Test System task identifier.
-    callback_url : str
-        Url to update Test System task execution result.
-    """
-    task_status = None
-    later = datetime.now() + timedelta(seconds=CONFIG.task_tracking_timeout)
-    session = Session()
-    logging.info(f'Starting to monitor task {task_id}')
-    while task_status not in READY_STATES and datetime.now() <= later:
-        try:
-            task_result = celery_app.AsyncResult(task_id)
-            task_status = task_result.state
-        except Exception as e:
-            logging.error(f'Cannot fetch task result for task ID {task_id}:'
-                          f' {e}')
-        try:
-            task_record = (session.query(Task).filter(Task.task_id == task_id)
-                           .first())
-            if task_record.status != task_status:
-                task_record.status = task_status
-                session.add(task_record)
-                session.commit()
-                logging.info(f'Updated task {task_id} status to {task_status}')
-        except Exception as e:
-            logging.error(f'Cannot update task DB record: {e}')
-        time.sleep(10)
-
-    if callback_url:
-        task_result = get_celery_task_result(task_id)
-        task_result['api_version'] = API_VERSION
-        requests.post(callback_url, json=task_result)
-
-    logging.info(f'Finished monitoring for task {task_id}')
-
-
 @app.on_event('startup')
 async def startup():
 
@@ -136,15 +95,40 @@ async def startup():
     #     # TODO: Add query to database and update tasks
     #     pass
     try:
-        for task in (session.query(Task.task_id, Task.status)
-                     .filter(Task.status == 'STARTED')):
+        tasks_for_update = []
+        for task in session.query(Task).filter(Task.status == 'STARTED'):
             task_result = celery_app.AsyncResult(task.task_id)
             task.status = task_result.state
-            session.add(task)
-        session.commit()
+            tasks_for_update.append(task)
+        if tasks_for_update:
+            session.add_all(tasks_for_update)
+            session.commit()
+            del tasks_for_update
     except Exception as e:
-        logging.error(f'Cannot save task info: {e}')
+        logging.error(f'Cannot save tasks info: {e}')
         session.rollback()
+    finally:
+        session.close()
+
+    global graceful_terminate_event
+    global terminate_event
+    global monitor
+
+    def signal_handler(signum, frame):
+        logging.info('Terminating all threads...')
+        terminate_event.set()
+
+    def sigusr_handler(signum, frame):
+        logging.info('Gracefully terminating all threads...')
+        graceful_terminate_event.set()
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGUSR1, sigusr_handler)
+
+    monitor = TasksMonitor(terminate_event, graceful_terminate_event,
+                           celery_app)
+    monitor.start()
 
 
 @app.on_event('shutdown')
@@ -153,6 +137,7 @@ async def shutdown():
     """Shutting down Test System task scheduler app."""
 
     await database.disconnect()
+    graceful_terminate_event.set()
 
 
 async def authenticate_user(credentials: str = Depends(http_bearer_scheme)):
@@ -300,8 +285,6 @@ async def schedule_task(task_data: TaskRequestPayload,
                                status='NEW')
             session.add(task_record)
             session.commit()
-            b_tasks.add_task(check_celery_task_result, task_id,
-                             callback_url=task_params.get('callback_url', ''))
             response_content.update({'success': True, 'task_id': task_id})
             return JSONResponse(status_code=201, content=response_content)
         except Exception as e:
@@ -310,3 +293,5 @@ async def schedule_task(task_data: TaskRequestPayload,
             response_content.update({'success': False, 'task_id': task_id,
                                      'error_description': str(e)})
             return JSONResponse(status_code=400, content=response_content)
+        finally:
+            session.close()

--- a/alts/scheduler/monitoring.py
+++ b/alts/scheduler/monitoring.py
@@ -1,0 +1,50 @@
+import logging
+import threading
+import time
+
+from celery.exceptions import TimeoutError
+from celery.states import READY_STATES
+
+from alts.scheduler.db import Session, Task
+
+
+class TasksMonitor(threading.Thread):
+    def __init__(self, terminated_event: threading.Event,
+                 graceful_terminate: threading.Event, celery_app,
+                 get_result_timeout: int = 1):
+        super().__init__()
+        self.__terminated_event = terminated_event
+        self.__graceful_terminate = graceful_terminate
+        self.__celery = celery_app
+        self.__get_result_timeout = get_result_timeout
+        self.logger = logging.getLogger(__file__)
+
+    def run(self) -> None:
+        while not self.__graceful_terminate.is_set() or \
+                not self.__terminated_event.is_set():
+            session = Session()
+            updated_tasks = []
+            for task in session.query(Task).filter(
+                    Task.status.notin_(READY_STATES)):
+                task_result = self.__celery.AsyncResult(task.task_id)
+                # Ensure that task state will be updated
+                # by getting task result
+                try:
+                    _ = task_result.get(timeout=self.__get_result_timeout)
+                except TimeoutError:
+                    pass
+                if task_result.state != task.status:
+                    self.logger.info(f'Updating task {task.task_id} status '
+                                     f'to {task_result.state}')
+                    task.status = task_result.state
+                    updated_tasks.append(task)
+
+            if updated_tasks:
+                try:
+                    session.add_all(updated_tasks)
+                    session.commit()
+                except Exception as e:
+                    self.logger.error(f'Cannot update tasks statuses: {e}')
+                    session.rollback()
+            session.close()
+            time.sleep(30)

--- a/alts/shared/constants.py
+++ b/alts/shared/constants.py
@@ -1,6 +1,9 @@
 
-__all__ = ['API_VERSION']
+__all__ = ['API_VERSION', 'ARCHITECTURES', 'COSTS', 'DRIVERS']
 
 
 # YYYYMMDD format for API version
 API_VERSION = '20210512'
+COSTS = [str(i) for i in range(5)]
+ARCHITECTURES = ['x86_64', 'x86', 'aarch64']
+DRIVERS = ['docker', 'opennebula']

--- a/alts/shared/constants.py
+++ b/alts/shared/constants.py
@@ -1,0 +1,6 @@
+
+__all__ = ['API_VERSION']
+
+
+# YYYYMMDD format for API version
+API_VERSION = '20210512'

--- a/alts/worker/app.py
+++ b/alts/worker/app.py
@@ -1,5 +1,9 @@
-from celery import Celery
+import itertools
 
+from celery import Celery
+from kombu import Exchange, Queue
+
+from alts.shared.constants import ARCHITECTURES, COSTS, DRIVERS
 from alts.shared.utils.path_utils import get_abspath
 from alts.worker import CONFIG
 
@@ -10,6 +14,19 @@ __all__ = ['celery_app']
 celery_app = Celery('alts', include=['alts.worker.tasks'])
 celery_app.config_from_object(CONFIG)
 celery_app.conf.update(result_accept_content=['json'])
+
+# Define all queues so client (scheduler) would be aware of all of them
+task_queues = [Queue('default', Exchange('default', type='direct'),
+                     routing_key='default')]
+for queue_tuple in itertools.product(DRIVERS, ARCHITECTURES, COSTS):
+    queue_name = '-'.join(queue_tuple)
+    task_queues.append(Queue(queue_name, Exchange(queue_name, type='direct'),
+                             routing_key=queue_name))
+
+celery_app.conf.task_queues = task_queues
+celery_app.conf.task_default_queue = 'default'
+celery_app.conf.task_default_exchange = 'default'
+celery_app.conf.task_default_routing_key = 'default'
 
 if CONFIG.use_ssl:
     if not CONFIG.ssl_config:

--- a/alts/worker/runners/base.py
+++ b/alts/worker/runners/base.py
@@ -309,8 +309,12 @@ class BaseRunner(object):
             Exit code, stdout and stderr from executed command
 
         """
+        if package_version:
+            full_pkg_name = f'{package_name}-{package_version}'
+        else:
+            full_pkg_name = package_name
         self._logger.info(f'Running package integrity tests for '
-                          f'{self.env_name}...')
+                          f'{full_pkg_name} on {self.env_name}...')
         cmd_args = ['--tap-stream', '--tap-files', '--tap-outdir',
                     self._artifacts_dir, '--hosts', 'ansible://all',
                     '--ansible-inventory', self._inventory_file_path,

--- a/alts/worker/runners/docker.py
+++ b/alts/worker/runners/docker.py
@@ -97,8 +97,10 @@ class DockerRunner(BaseRunner):
         """
         super().prepare_work_dir_files(
             create_ansible_inventory=create_ansible_inventory)
+        run_script_path = os.path.join(self._work_dir, self.DOCKER_RUN_SCRIPT)
         shutil.copy(os.path.join(RESOURCES_DIR, self.TYPE, self.DOCKER_RUN_SCRIPT),
-                    os.path.join(self._work_dir, self.DOCKER_RUN_SCRIPT))
+                    run_script_path)
+        os.chmod(run_script_path, 755)
 
     def _exec(self, cmd_with_args: ()):
         """

--- a/deployment/templates/alts-celery.service.j2
+++ b/deployment/templates/alts-celery.service.j2
@@ -7,9 +7,8 @@ User={{ test_system_user }}
 Group={{ test_system_user }}
 Environment=CELERY_CONFIG_PATH={{ test_system_config_dir }}/celery.yaml
 ExecStart=/bin/sh -c 'source {{ celery_venv_dir }}/bin/activate && cd ~/alts && celery -A alts.worker.app worker \
-    --pool=threads --concurrency={{ celery_concurrency }} --loglevel={{ celery_loglevel }} \
+    --pool=prefork --concurrency={{ celery_concurrency }} --loglevel={{ celery_loglevel }} \
     -Q {{ celery_queues|join(",") }} --pidfile={{ celery_pid_file }}'
-ExecStop=/bin/sh -c 'source {{ celery_venv_dir }}/bin/activate && celery -A alts.worker.app stop --pidfile={{ celery_pid_file }}'
 
 [Install]
 WantedBy=multi-user.target

--- a/resources/docker/docker.tf.tmpl
+++ b/resources/docker/docker.tf.tmpl
@@ -13,12 +13,7 @@ resource "docker_container" "${container_name}" {
   }
 }
 
-data "docker_registry_image" "${dist_name}" {
-  name = "quay.io/${dist_name}/${dist_name}:${dist_version}"
-}
-
 resource "docker_image" "${dist_name}" {
-  name          = data.docker_registry_image.${dist_name}.name
-  pull_triggers = [data.docker_registry_image.${dist_name}.sha256_digest]
+  name          = "${dist_name}:${dist_version}"
   keep_locally = true
 }

--- a/resources/docker/docker.tf.tmpl
+++ b/resources/docker/docker.tf.tmpl
@@ -14,7 +14,7 @@ resource "docker_container" "${container_name}" {
 }
 
 data "docker_registry_image" "${dist_name}" {
-  name = "${image_arch}/${dist_name}:${dist_version}"
+  name = "quay.io/${dist_name}/${dist_name}:${dist_version}"
 }
 
 resource "docker_image" "${dist_name}" {


### PR DESCRIPTION
Currently we monitor tasks statuses using FastAPI background tasks.
The caveat is that they use the same event pool API itself uses and
this adds problems with system reliability.
This commit adds additional monitoring thread as well as some stability
fixes, especially regarding database communication.