### PR TITLE
Implemented integration with new build system

### DIFF
--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -1,7 +1,7 @@
 FROM almalinux:8
 
 ARG ARCH="amd64"
-ARG TF_VERSION="1.0.5"
+ARG TF_VERSION="1.0.6"
 
 RUN mkdir -p /code ~/.terraform.d/plugin-cache ~/.ssh /srv/celery_results \
     && echo "plugin_cache_dir = \"\$HOME/.terraform.d/plugin-cache\"" > ~/.terraformrc \

--- a/alts/scheduler/monitoring.py
+++ b/alts/scheduler/monitoring.py
@@ -1,4 +1,5 @@
 import logging
+import random
 import threading
 import time
 
@@ -38,6 +39,7 @@ class TasksMonitor(threading.Thread):
                                      f'to {task_result.state}')
                     task.status = task_result.state
                     updated_tasks.append(task)
+                time.sleep(0.5)
 
             if updated_tasks:
                 try:
@@ -47,4 +49,4 @@ class TasksMonitor(threading.Thread):
                     self.logger.error(f'Cannot update tasks statuses: {e}')
                     session.rollback()
             session.close()
-            time.sleep(30)
+            self.__terminated_event.wait(random.randint(5, 10))

--- a/alts/shared/constants.py
+++ b/alts/shared/constants.py
@@ -5,5 +5,5 @@ __all__ = ['API_VERSION', 'ARCHITECTURES', 'COSTS', 'DRIVERS']
 # YYYYMMDD format for API version
 API_VERSION = '20210512'
 COSTS = [str(i) for i in range(5)]
-ARCHITECTURES = ['x86_64', 'x86', 'aarch64']
-DRIVERS = ['docker', 'opennebula']
+ARCHITECTURES = ('x86_64', 'aarch64')
+DRIVERS = ('docker', 'opennebula')

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
     environment:
       CELERY_CONFIG_PATH: "/celery_config.yaml"
     command: "bash -c 'source env/bin/activate && celery
-      -A alts.worker.app worker --pool=threads --concurrency=10
-      --loglevel=INFO -Q docker-x86_64-0,opennebula-x86_64-0'"
+      -A alts.worker.app worker --pool=threads --concurrency=20
+      --loglevel=INFO -Q docker-x86_64-0'"
     restart: on-failure
     privileged: true
     volumes:
@@ -56,7 +56,7 @@ services:
       CELERY_CONFIG_PATH: "/scheduler_config.yaml"
       SCHEDULER_CONFIG_PATH: "/scheduler_config.yaml"
     command: "bash -c 'source env/bin/activate && uvicorn --host 0.0.0.0
-      alts.scheduler.app:app'"
+      alts.scheduler.app:app --limit-concurrency 100 --backlog 1000'"
     restart: on-failure
     ports:
       - 8000:8000

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,3 +9,5 @@ requests==2.25.1
 cryptography==3.4.7
 azure-storage-blob==12.8.1
 tap.py==3.0
+amqp==5.0.6
+librabbitmq==2.0.0

--- a/resources/docker/docker.tf.tmpl
+++ b/resources/docker/docker.tf.tmpl
@@ -6,11 +6,12 @@ resource "docker_container" "${container_name}" {
   image = docker_image.${dist_name}.latest
   name = "${container_name}"
   must_run = true
-  command = ["/run.sh",]
-  volumes {
-    host_path = "${work_dir}/run.sh"
-    container_path = "/run.sh"
+  command = ["sleep", "21600"]
+% if external_network:
+  networks_advanced {
+    name = "${external_network}"
   }
+% endif
 }
 
 resource "docker_image" "${dist_name}" {

--- a/resources/docker/run.sh
+++ b/resources/docker/run.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-while :; do :; done & kill -STOP $! && wait $!


### PR DESCRIPTION
This change fixes some integrational challenges when getting tasks
from new build system:
- 32-bit x86 packages will be tested inside 64-bit containers;
- 'callback_url' is changed to 'callback_href' in order to be able
  to implement proper authentication/authorization frow with new build
  system;
- Celery configuration was tweaked to provide more stability;