### PR TITLE
Run integrity tests from inside the container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -304,3 +304,4 @@ terraform.rc
 # Ignore configs for docker-compose deploy
 configs/alts_config*.yaml
 deployment
+venv*

--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+venv*
 
 # Spyder project settings
 .spyderproject

--- a/alts/shared/models.py
+++ b/alts/shared/models.py
@@ -32,7 +32,7 @@ class TaskRequestPayload(BaseModel):
         # TODO: Add config or constant to have all possible runner types
         runner_types = constants.DRIVERS + ('any',)
         if value not in runner_types:
-            raise ValidationError(f'Unknown runner type: {value}')
+            raise ValidationError(f'Unknown runner type: {value}', cls)
         return value
 
 

--- a/alts/worker/runners/base.py
+++ b/alts/worker/runners/base.py
@@ -338,19 +338,18 @@ class BaseRunner(object):
             Exit code, stdout and stderr from executed command
 
         """
-        if package_version:
-            full_pkg_name = f'{package_name}-{package_version}'
-        else:
-            full_pkg_name = package_name
-        self._logger.info(f'Running package integrity tests for '
-                          f'{full_pkg_name} on {self.env_name}...')
         cmd_args = ['--tap-stream', '--tap-files', '--tap-outdir',
                     self._artifacts_dir, '--hosts', 'ansible://all',
                     '--ansible-inventory', self._inventory_file_path,
                     '--package-name', package_name]
         if package_version:
+            full_pkg_name = f'{package_name}-{package_version}'
             cmd_args.extend(['--package-version', package_version])
+        else:
+            full_pkg_name = package_name
         cmd_args.append('tests')
+        self._logger.info('Running package integrity tests for '
+                          '%s on %s...', full_pkg_name, self.env_name)
         return local['py.test'].run(args=cmd_args, retcode=None,
                                     cwd=self._integrity_tests_dir)
 
@@ -424,8 +423,8 @@ class BaseRunner(object):
             try:
                 self.publish_artifacts_to_storage()
             except Exception as e:
-                self._logger.warning('Exception while publishing artifacts: '
-                                     '%s', str(e))
+                self._logger.exception('Exception while publishing artifacts: '
+                                       '%s', str(e))
         self.erase_work_dir()
 
 

--- a/alts/worker/runners/base.py
+++ b/alts/worker/runners/base.py
@@ -421,7 +421,11 @@ class BaseRunner(object):
     def teardown(self, publish_artifacts: bool = True):
         self.stop_env()
         if publish_artifacts:
-            self.publish_artifacts_to_storage()
+            try:
+                self.publish_artifacts_to_storage()
+            except Exception as e:
+                self._logger.warning('Exception while publishing artifacts: '
+                                     '%s', str(e))
         self.erase_work_dir()
 
 

--- a/alts/worker/runners/docker.py
+++ b/alts/worker/runners/docker.py
@@ -146,15 +146,14 @@ class DockerRunner(BaseRunner):
             Exit code, stdout and stderr from executed command
 
         """
-        if package_version:
-            full_pkg_name = f'{package_name}-{package_version}'
-        else:
-            full_pkg_name = package_name
-        self._logger.info(f'Running package integrity tests for '
-                          f'{full_pkg_name} on {self.env_name}...')
         cmd_args = ['py.test', '--rootdir', '/tests', '--tap-stream',
                     '--package-name', package_name]
         if package_version:
+            full_pkg_name = f'{package_name}-{package_version}'
             cmd_args.extend(['--package-version', package_version])
+        else:
+            full_pkg_name = package_name
         cmd_args.append('tests')
+        self._logger.info('Running package integrity tests for '
+                          '%s on %s...', full_pkg_name, self.env_name)
         return self._exec(cmd_args)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,8 +1,8 @@
 celery==5.1.2
-mako==1.1.4
+mako==1.1.6
 plumbum==1.7.0
-boto3==1.17.50
-pydantic==1.8.1
+boto3==1.20.10
+pydantic==1.8.2
 ruamel.yaml==0.17.4
 jmespath==0.10.0
 requests==2.25.1

--- a/requirements/scheduler.txt
+++ b/requirements/scheduler.txt
@@ -1,6 +1,6 @@
 -r base.txt
-fastapi==0.63.0
-databases[sqlite]==0.4.3
-SQLAlchemy<1.4
-uvicorn==0.13.4
+fastapi==0.70.0
+databases[sqlite]==0.5.3
+SQLAlchemy==1.4.27
+uvicorn==0.15.0
 python-jose==3.2.0

--- a/resources/docker/docker.tf.tmpl
+++ b/resources/docker/docker.tf.tmpl
@@ -12,6 +12,11 @@ resource "docker_container" "${container_name}" {
     name = "${external_network}"
   }
 % endif
+  volumes {
+    host_path = "${tests_dir}/"
+    container_path = "/tests"
+    read_only = true
+  }
 }
 
 resource "docker_image" "${dist_name}" {

--- a/resources/package_tests/base.py
+++ b/resources/package_tests/base.py
@@ -143,8 +143,10 @@ def resolve_symlink(host: Host, file_: Union[str, GNUFile],
         resolve_depth -= 1
 
     resolve_out = '\n'.join(resolve_items)
-    raise ValueError(f'Broken or circular symlink found: {initial_file}\n'
-                     f'Full resolution output:\n{resolve_out}')
+    message = f'Broken or circular symlink found: {initial_file}'
+    if resolve_out:
+        message += '\nFull resolution output:\n{resolve_out}'
+    raise ValueError(message)
 
 
 def has_missing_shared_libraries(file_: GNUFile) -> MissingSOResult:

--- a/resources/package_tests/tests/test_package_is_correct.py
+++ b/resources/package_tests/tests/test_package_is_correct.py
@@ -1,3 +1,4 @@
+import pytest_check as check
 from testinfra.modules.package import RpmPackage
 
 from ..base import *
@@ -24,9 +25,10 @@ def test_package_is_installed(host, package_name, package_version):
     package = host.package(package_name)
     assert package.is_installed
     if package_version:
-        assert package.version in package_version
+        check.is_in(package.version, package_version, 'Version does not match')
         if isinstance(package, RpmPackage):
-            assert package.release in package_version
+            check.is_in(package.release, package_version,
+                        'Release does not match')
 
 
 def test_all_package_files_exist(host, package_name):
@@ -51,10 +53,13 @@ def test_all_package_files_exist(host, package_name):
 
     for file_ in get_package_files(package):
         file_obj = host.file(file_)
-        assert file_obj.exists
+        check.is_true(file_obj.exists)
         # Check all symlinks point to existing files
         if file_obj.is_symlink:
-            resolve_symlink(host, file_obj)
+            resolved = resolve_symlink(host, file_obj)
+            check.is_not_none(resolved)
+            file_obj = host.file(resolved)
+            check.is_true(file_obj.exists)
 
 
 def test_binaries_have_all_dependencies(host, package_name):
@@ -83,7 +88,7 @@ def test_binaries_have_all_dependencies(host, package_name):
             file_ = host.file(resolve_symlink(host, file_))
         if is_file_dynamically_linked(file_):
             check_result = has_missing_shared_libraries(file_)
-            assert not check_result.missing, check_result.output
+            check.is_false(check_result.missing, check_result.output)
 
 
 def test_check_rpath_is_correct(host, package_name):
@@ -107,4 +112,4 @@ def test_check_rpath_is_correct(host, package_name):
         return
 
     for library in get_shared_libraries(package):
-        assert is_rpath_correct(host.file(library))
+        check.is_true(is_rpath_correct(host.file(library)))

--- a/resources/package_tests/tests/test_package_is_correct.py
+++ b/resources/package_tests/tests/test_package_is_correct.py
@@ -23,7 +23,7 @@ def test_package_is_installed(host, package_name, package_version):
     """
 
     package = host.package(package_name)
-    assert package.is_installed
+    check.is_true(package.is_installed)
     if package_version:
         check.is_in(package.version, package_version, 'Version does not match')
         if isinstance(package, RpmPackage):

--- a/resources/playbook.yml
+++ b/resources/playbook.yml
@@ -12,7 +12,7 @@
 
         - name: Install file package
           yum:
-            name: file
+            name: ["file", "python3-pip"]
             state: present
 
         - name: Add required repositories
@@ -42,6 +42,16 @@
           with_items: "{{ repositories }}"
           when: repositories is defined and (repositories | length > 0)
       when: ansible_distribution_file_variety == 'Debian'
+      tags:
+        - initial_provision
+
+    - name: Install tools for running tests
+      pip:
+        name:
+          - pytest
+          - pytest-testinfra
+          - pytest-check
+          - pytest-tap
       tags:
         - initial_provision
 


### PR DESCRIPTION
Current flow is to run testinfra from host machine. The issue
with this approach is that overhead on communicating with the
test container is too high: basically every command in the test
needs to go through ansible and this cripples tests performance
on big packages. New approach is to mount tests into test container
and run testinfra from inside it.