### PR TITLE
Ansible package has been deprecated

### DIFF
--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -6,7 +6,7 @@ RUN mkdir -p /code ~/.terraform.d/plugin-cache ~/.ssh /srv/celery_results \
     && yum install -y python3-virtualenv python39 epel-release wget unzip yum-utils openssh-clients \
     && yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo \
     && yum-config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo \
-    && yum install -y docker-ce docker-ce-cli containerd.io ansible terraform --enablerepo=epel \
+    && yum install -y docker-ce docker-ce-cli containerd.io ansible-core terraform --enablerepo=epel \
     && yum clean all \
     && cat /dev/zero | ssh-keygen -t rsa -b 4096 -f ~/.ssh/id_rsa -q -N ""
 COPY requirements/ /tmp/requirements


### PR DESCRIPTION
Hello everyone, I've got failed deployment because of ansible package deprecation.
https://access.redhat.com/discussions/6962395

`'Adding repo from: https://download.docker.com/linux/centos/docker-ce.repo\n', 
'Adding repo from: https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo\n', 
'Docker CE Stable - x86_64                       296 kB/s |  31 kB     00:00    \n', 
'Extra Packages for Enterprise Linux 8 - x86_64   10 MB/s |  13 MB     00:01    \n', 
'Extra Packages for Enterprise Linux Modular 8 - 104 kB/s | 733 kB     00:07    \n', 
'Hashicorp Stable - x86_64                       2.6 MB/s | 917 kB     00:00    \n', 
'\x1b[91mError: \n Problem: conflicting requests\n  - nothing provides (ansible-core >= 2.12.2 with ansible-core < 2.13) needed by ansible-5.4.0-3.el8.noarch\n\x1b[0m', "(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)\n", 'Removing intermediate container 97e48e1260b1\n'`