### PR TITLE
Fix false-negative test results in several cases

### DIFF
--- a/resources/files/custom-ts.conf
+++ b/resources/files/custom-ts.conf
@@ -1,0 +1,1 @@
+/usr/lib64/firefox

--- a/resources/package_tests/base.py
+++ b/resources/package_tests/base.py
@@ -42,7 +42,7 @@ def get_package_files(pkg: Union[DebianPackage, RpmPackage]) -> List[str]:
     if isinstance(pkg, DebianPackage):
         command = f'dpkg -L {pkg.name}'
     elif isinstance(pkg, RpmPackage):
-        command = f'rpm -ql {pkg.name}'
+        command = f'rpm -ql --noghost {pkg.name}'
     else:
         raise ValueError(f'Unknown package type: {type(pkg)}')
 
@@ -189,7 +189,7 @@ def has_missing_shared_libraries(file_: GNUFile) -> MissingSOResult:
 
     """
     output = file_.run(f'ldd {file_.path}')
-    result = []
+    result = [f'File {file_.path} has missing shared libraries dependencies:']
     assert output.rc == 0
     for item in output.stdout.split('\n'):
         if 'not found' in item.lower():

--- a/resources/playbook.yml
+++ b/resources/playbook.yml
@@ -100,6 +100,17 @@
       tags:
         - initial_provision
 
+    - name: Install custom ldconfig
+      copy:
+        src: custom-ts.conf
+        dest: /etc/ld.so.conf.d/custom-ts.conf
+        owner: root
+        group: root
+        mode: 0644
+
+    - name: Reload ldconfig
+      shell: ldconfig
+
     - name: Enable module
       shell: dnf module enable -y "{{ module_name }}:{{ module_stream }}:{{ module_version }}"
       when: ansible_distribution_file_variety == 'RedHat' and module_name is defined and module_stream is defined and module_version is defined


### PR DESCRIPTION
The following false-negative cases were fixed:
- When package has 'ghost' files: such file may not exist at the installation time, but may be created by user later on and will be deleted when package is uninstalled;
- When package libraries are installed in custom path. For example, Firefox stores its libraries in `/usr/lib64/firefox` location.

https://github.com/AlmaLinux/build-system/issues/114