### PR TITLE
Inherit host's proxy env vars in generated containers

### DIFF
--- a/alts/worker/runners/docker.py
+++ b/alts/worker/runners/docker.py
@@ -113,8 +113,11 @@ class DockerRunner(BaseRunner):
         """
         docker_tf_file = os.path.join(self._work_dir, self.TF_MAIN_FILE)
         image_name = f'{self.dist_name}:{self.dist_version}'
-        external_network = os.environ.get('EXTERNAL_NETWORK', None)
         image_platform = ARCH_PLATFORM_MAPPING.get(self.dist_arch)
+        external_network = os.environ.get('EXTERNAL_NETWORK', None)
+        http_proxy = os.environ.get('http_proxy', None)
+        https_proxy = os.environ.get('https_proxy', None)
+        no_proxy = os.environ.get('no_proxy', None)
 
         self._render_template(
             f'{self.TF_MAIN_FILE}.tmpl',
@@ -124,6 +127,9 @@ class DockerRunner(BaseRunner):
             dist_name=self.dist_name,
             image_name=image_name,
             image_platform=image_platform,
+            http_proxy=http_proxy,
+            https_proxy=https_proxy,
+            no_proxy=no_proxy,
         )
 
     def _render_tf_variables_file(self):

--- a/resources/docker/docker.tf.tmpl
+++ b/resources/docker/docker.tf.tmpl
@@ -7,6 +7,17 @@ resource "docker_container" "${container_name}" {
   name = "${container_name}"
   must_run = true
   command = ["sleep", "21600"]
+  env = [
+% if http_proxy:
+    "http_proxy=${http_proxy}",
+% endif
+% if https_proxy:
+    "https_proxy=${https_proxy}",
+% endif
+% if no_proxy:
+    "no_proxy=${no_proxy}",
+% endif
+  ]
 % if external_network:
   networks_advanced {
     name = "${external_network}"

--- a/resources/roles/preparation/tasks/rhel.yml
+++ b/resources/roles/preparation/tasks/rhel.yml
@@ -55,6 +55,7 @@
 - name: Add YUM proxy
   ini_file:
     path: /etc/yum.conf
+    follow: yes
     section: main
     option: proxy
     value: "{{ package_proxy }}"
@@ -63,6 +64,7 @@
 - name: Remove nodocs param from YUM config
   ini_file:
     path: /etc/yum.conf
+    follow: yes
     section: main
     option: tsflags
     state: absent
@@ -70,6 +72,7 @@
 - name: Remove override_install_langs from YUM config
   ini_file:
     path: /etc/yum.conf
+    follow: yes
     section: main
     option: override_install_langs
     state: absent


### PR DESCRIPTION
In Docker CLI, you can configure proxy settings for generated containers
by setting up ~/.docker/config.json. However, Docker provider in
Terraform does not read this file, so proxy env vars need to be
specified directory.

Resolves: https://github.com/AlmaLinux/build-system/issues/321