### PR TITLE
Enable timestamps in ansible logs

### DIFF
--- a/resources/ansible.cfg
+++ b/resources/ansible.cfg
@@ -7,6 +7,7 @@ forks = 1
 interpreter_python = auto_legacy_silent
 stdout_callback = yaml
 gather_subset = !all
+callbacks_enabled=ansible.posix.profile_tasks
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa -o HostKeyAlgorithms=+ssh-rsa
@@ -14,3 +15,7 @@ pipelining = True
 
 [persistent_connection]
 command_timeout = 590
+
+[callback_profile_tasks]
+sort_order = none
+output_limit = 50


### PR DESCRIPTION
Resolves: AlmaLinux/build-system#337