### PR TITLE
Fix minimal tests for curl on centos8els

### DIFF
--- a/resources/roles/install_uninstall/tasks/main.yml
+++ b/resources/roles/install_uninstall/tasks/main.yml
@@ -14,13 +14,24 @@
   tags:
     - install_package
 
-- name: Install RPM package
+- name: Install RPM package (8 and higher)
+  dnf:
+    name: "{{ pkg_name }}"
+    state: present
+    allow_downgrade: true
+    allowerasing: true
+    lock_timeout: 300
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version >= '8'
+  tags:
+    - install_package
+
+- name: Install RPM package (7 and lower)
   yum:
     name: "{{ pkg_name }}"
     state: present
     allow_downgrade: true
     lock_timeout: 300
-  when: ansible_facts.os_family == 'RedHat'
+  when: ansible_facts.os_family == 'RedHat' and ansible_facts.distribution_major_version < '8'
   tags:
     - install_package
 


### PR DESCRIPTION
Tests used to fail due to `curl-minimal ` conflict with already installed `curl` when installing on Centos8 platform. 
- Added `allowerasing` flag to resolve conflicting packages.

Resolves: https://cloudlinux.atlassian.net/browse/AL-5469