### PR TITLE
Add redis to docker-compose.yml (#112)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - ".:/code"
     depends_on:
       - rabbitmq
+      - redis
 
   scheduler:
     image: alts-scheduler:latest
@@ -51,6 +52,9 @@ services:
       - ".:/code"
     depends_on:
       - rabbitmq
+
+  redis:
+    image: redis
 
   alts_tests:
     image: alts-tests:latest


### PR DESCRIPTION
Celery is using it as the results backend