### PR TITLE
AL-5830: move Opennebula templates lookup to terraform

### DIFF
--- a/resources/opennebula/opennebula.tf.tmpl
+++ b/resources/opennebula/opennebula.tf.tmpl
@@ -14,12 +14,29 @@ data "opennebula_virtual_network" "test_system_network" {
   name = "${opennebula_network}"
 }
 
-data "opennebula_template" "selected_template" {
-  id = ${template_id}
+data "opennebula_templates" "filtered_templates" {
+  name_regex = "${template_regex_str}"
+  sort_on    = "register_date"
+  order      = "ASC" # order from newer to older
 }
 
 locals {
-  disk_0 = data.opennebula_template.selected_template.disk[0]
+  all_templates = data.opennebula_templates.filtered_templates.templates
+
+  # filtering through templates with specific channels
+  templates_with_channels = [
+    for t in local.all_templates : t
+    if length(regexall("\\.${channel}\\.", t.name)) > 0
+  ]
+
+  has_templates_with_channels = length(local.templates_with_channels) > 0
+
+  selected_template = (
+    local.has_templates_with_channels ? local.templates_with_channels[0] :
+    local.all_templates[0]
+  )
+
+  disk_0 = local.selected_template.disk[0]
   disk_size = max(
     local.disk_0.size,        # Original disk size from template
     15360,                    # Minimum required size
@@ -29,7 +46,7 @@ locals {
 
 resource "opennebula_virtual_machine" "${vm_name}" {
   name = "${vm_name}"
-  template_id = ${template_id}
+  template_id = local.selected_template.id
   permissions = "660"
   group = "${opennebula_vm_group}"
   memory = "${vm_ram_size}"

--- a/resources/opennebula/opennebula.tf.tmpl
+++ b/resources/opennebula/opennebula.tf.tmpl
@@ -78,3 +78,7 @@ output "vm_ip" {
 output "vm_id" {
   value = opennebula_virtual_machine.${vm_name}.id
 }
+
+output "template_name" {
+  value = local.selected_template.name
+}

--- a/tests/runners/test_opennebula_runner.py
+++ b/tests/runners/test_opennebula_runner.py
@@ -1,0 +1,65 @@
+import re
+from unittest.mock import patch
+
+from alts.worker.runners import OpennebulaRunner
+
+
+def runner_payload():
+    """Helper method to generate common OpennebulaRunner kwargs."""
+    return {
+        'task_id': 'task123',
+        'task_is_aborted': lambda: False,
+        'dist_name': 'test-name',
+        'dist_version': '1.0',
+        'dist_arch': 'x86_64',
+        'test_flavor': {'name': 'cloud', 'version': '1.0'},
+    }
+
+
+class TestOpennebulaRunner:
+
+    @patch('alts.worker.runners.opennebula.CONFIG')
+    @patch('alts.worker.runners.opennebula.pyone.OneServer')
+    def test_opennebula_runner_init(self, mock_one_server, mock_config):
+        mock_config.opennebula_config.username = 'testuser'
+        mock_config.opennebula_config.password = 'testpass'
+        mock_config.opennebula_config.rpc_endpoint = 'http://example.com/RPC2'
+
+        runner = OpennebulaRunner(**runner_payload())
+
+        assert runner._task_id == 'task123'
+        assert runner.dist_name == 'test-name'
+        assert runner.dist_version == '1.0'
+        mock_one_server.assert_called_once_with(
+            uri='http://example.com/RPC2', session='testuser:testpass'
+        )
+
+    @patch('alts.worker.runners.opennebula.CONFIG')
+    def test_get_opennebula_template_regex(self, mock_config):
+        allowed_channel_names = ['channel1', 'channel2']
+
+        mock_config.allowed_channel_names = allowed_channel_names
+        mock_config.opennebula_config.username = 'testuser'
+        mock_config.opennebula_config.password = 'testpass'
+        mock_config.opennebula_config.rpc_endpoint = 'http://example.com/RPC2'
+
+        runner = OpennebulaRunner(**runner_payload())
+        regex = runner.get_opennebula_template_regex()
+
+        # It should be a Terraform-safe regex string with escaped backslashes
+        assert (
+            regex
+            == r'test-name-1.0-(x86_64)\\.cloud-1.0\\.test_system\\.(channel1|channel2)\\.b\\d{8}-\\d+'
+        )
+
+        match = re.match(
+            re.compile(regex.replace('\\\\', '\\')),  # Unescape for real use
+            r'test-name-1.0-x86_64.cloud-1.0.test_system.channel2.b20251234-567',
+        )
+        assert match is not None
+
+        match = re.match(
+            re.compile(regex.replace('\\\\', '\\')),  # Unescape for real use
+            r'test-name-1.0-aarch64.cloud-1.0.test_system.channel2.b20251234-567',
+        )
+        assert match is None


### PR DESCRIPTION
- OpenNebulaRunner now doesn't look up template_id via OpenNebula API
- It generates a regex string to pass to terraform for searching
- The rest of the look up logic is moved to `opennebula.tf.tmpl`

Fixes: https://cloudlinux.atlassian.net/browse/AL-5830