### PR TITLE
Set fixed version for terraform.opennebula provider

### DIFF
--- a/resources/opennebula/versions.tf
+++ b/resources/opennebula/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     opennebula = {
       source = "OpenNebula/opennebula"
+      version = "1.4.1"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
Reason: with update to 1.5.0 version of Opennebula provider, the provider started introducing many bugs Until it's stable, it's better to stay with the previous one