### PR TITLE
Disable installation of recommended DEB packages

### DIFF
--- a/resources/roles/install_uninstall/tasks/main.yml
+++ b/resources/roles/install_uninstall/tasks/main.yml
@@ -90,6 +90,7 @@
     name: "{{ pkg_name }}"
     state: present
     allow_unauthenticated: true
+    install_recommends: no
   when: ansible_distribution_file_variety == 'Debian'
   tags:
     - install_package


### PR DESCRIPTION
Recommended dependencies may lead to the installation of large meta packages like gnome or firefox. 

This tiny change should fix this behaviour.