### PR TITLE
Add timeout for GET requests in alts-scheduler

### DIFF
--- a/alts/scheduler/scheduling.py
+++ b/alts/scheduler/scheduling.py
@@ -11,6 +11,7 @@ import requests
 
 from alts.scheduler import CONFIG
 from alts.scheduler.db import Session, Task
+from alts.shared.constants import DEFAULT_REQUEST_TIMEOUT
 from alts.shared.models import TaskRequestPayload
 from alts.worker.mappings import RUNNER_MAPPING
 from alts.worker.tasks import run_tests
@@ -45,6 +46,7 @@ class TestsScheduler(threading.Thread):
                     CONFIG.bs_tasks_endpoint,
                 ),
                 headers={'Authorization': f'Bearer {CONFIG.bs_token}'},
+                timeout=DEFAULT_REQUEST_TIMEOUT,
             )
             response.raise_for_status()
             response_as_json = response.json()


### PR DESCRIPTION
Resolves: https://github.com/AlmaLinux/build-system/issues/528