### PR TITLE
PF-168: use classmethod for runner queue cost determination

### DIFF
--- a/alts/scheduler/scheduling.py
+++ b/alts/scheduler/scheduling.py
@@ -124,7 +124,7 @@ class TestsScheduler(threading.Thread):
                 repo_counter += 1
             repositories.append({'url': repository.baseurl, 'name': repo_name})
 
-        queue_name = f'{runner_type}-{queue_arch}-{runner_class.COST}'
+        queue_name = f'{runner_type}-{queue_arch}-{runner_class.get_cost(payload.release_build)}'
         task_id = str(uuid.uuid4())
         task_params = payload.model_dump()
         task_params['task_id'] = task_id

--- a/alts/worker/runners/base.py
+++ b/alts/worker/runners/base.py
@@ -189,6 +189,11 @@ class BaseRunner(object):
         s390x=['s390x'],
     )
     COST = 0
+
+    @classmethod
+    def get_cost(cls, release_build: bool = False) -> int:
+        return cls.COST
+
     TF_VARIABLES_FILE = None
     TF_MAIN_FILE = None
     TF_VERSIONS_FILE = 'versions.tf'

--- a/alts/worker/runners/opennebula.py
+++ b/alts/worker/runners/opennebula.py
@@ -35,6 +35,13 @@ class OpennebulaRunner(GenericVMRunner):
     """Opennebula environment runner for testing tasks."""
 
     TYPE = 'opennebula'
+    COST_STANDARD = 1
+    COST_RELEASE_BUILD = 2
+
+    @classmethod
+    def get_cost(cls, release_build: bool = False) -> int:
+        return cls.COST_RELEASE_BUILD if release_build else cls.COST_STANDARD
+
     TEMPFILE_PREFIX = 'opennebula_test_runner_'
     TF_VARIABLES_FILE = 'opennebula.tfvars'
     TF_MAIN_FILE = 'opennebula.tf'


### PR DESCRIPTION
Replaces hardcoded runner_type checks in the scheduler with a get_cost(release_build) classmethod. Base class returns COST by default; OpennebulaRunner overrides it to return COST_STANDARD=1 or COST_RELEASE_BUILD=2. COST=0 is preserved as the emergency routing queue.