### PR TITLE
Add centos7 repos for CentOS 7 VMs

### DIFF
--- a/resources/roles/preparation/tasks/rhel.yml
+++ b/resources/roles/preparation/tasks/rhel.yml
@@ -79,10 +79,9 @@
   with_items:
     - "os"
     - "updates"
-  when:
-    - ansible_distribution_file_variety in ('RedHat', 'CentOS')
-    - ansible_connection == 'docker'
-    - ansible_facts.distribution_major_version == '7'
+  when: >
+    (ansible_distribution == 'CentOS' and ansible_facts.distribution_major_version == '7') or
+    (ansible_distribution_file_variety in ('RedHat', 'CentOS') and ansible_connection == 'docker' and ansible_facts.distribution_major_version == '7')
 
 - name: Add YUM proxy
   ini_file:


### PR DESCRIPTION
PR #216 restricted adding the centos7 os/updates repos to Docker containers only (ansible_connection == 'docker'), which stopped them from being added on CentOS 7 VMs. Add a condition so the repos are also added on actual CentOS 7 hosts, while keeping the Docker el7 case intact.